### PR TITLE
Changes db from localhost to localdb and updates README with instructions.

### DIFF
--- a/MinecraftBlockIndex/AddBlockDB.cs
+++ b/MinecraftBlockIndex/AddBlockDB.cs
@@ -13,7 +13,7 @@ namespace MinecraftBlockIndex
         private static SqlConnection GetDatabaseConnection()
         {
             // Establish a connection to the database
-            return new SqlConnection("Data Source=localhost;Initial Catalog=MinecraftBlockIndex;Integrated Security=True;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False");
+            return new SqlConnection("Data Source=localdb;Initial Catalog=MinecraftBlockIndex;Integrated Security=True;Connect Timeout=30;Encrypt=True;Trust Server Certificate=True;Application Intent=ReadWrite;Multi Subnet Failover=False");
 
         }
     }

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ texture using basic CRUD operations.
 - [Recommended to use Visual Studio](https://dotnet.microsoft.com/en-us/download/dotnet)
 - Open the project in Visual Studio.
 
+## Database Information
+- This project utilizes a Microsoft SQL database and will connect to that database using `localdb`. To change this behavior, modify the [connection string](./MinecraftBlockIndex/AddBlockDB.cs).
+- 


### PR DESCRIPTION
Closes #9 

- Updated the connection string to use `localdb` because that is best practice. 
- Added instructions to the README about the database.